### PR TITLE
Added code to remove usg files post build.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,4 +42,6 @@ usg fix cis_level1_server
 echo "Cleaning up ua"
 apt-get purge --auto-remove -y \
   ubuntu-advantage-tools && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/lib/usg
+


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added code to build.sh to remove files created by usg.
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
There are no security considerations for this change.
[Note the any security considerations here, or make note of why there are none]
