### PR TITLE
Adds empty dockerenv file

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,6 +36,9 @@ apt-get -y -q install \
 echo "Installing grype cli"
 curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
+echo "Create dockerenv file"
+touch /.dockerenv
+
 echo "UA hardening"
 usg fix cis_level1_server
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Creates an empty `.dockerenv` file so that the cis fix and audit scripts are aware that we are running them in a container

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This makes our audit results more accurate
