### PR TITLE
Vars are required by new pipeline version

### DIFF
--- a/ci/vars.yml
+++ b/ci/vars.yml
@@ -1,2 +1,4 @@
 # vars.yml
+base-image: ubuntu
+base-image-tag: "22.04"
 oci-build-params: {}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Vars were added to oci-build step and must be added to the pipeline.
- See also https://github.com/cloud-gov/common-pipelines/pull/17. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.
