### PR TITLE
Remove permission changes for log files

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,4 +47,3 @@ apt-get purge --auto-remove -y \
   ubuntu-advantage-tools && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/lib/usg
-  

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,9 +39,6 @@ curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh 
 echo "Create dockerenv file"
 touch /.dockerenv
 
-echo "Update permissions of apt log files"
-chmod 640 /var/log/apt/*
-
 echo "UA hardening"
 usg fix cis_level1_server
 
@@ -51,3 +48,5 @@ apt-get purge --auto-remove -y \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/lib/usg
 
+echo "Update permissions of apt log files"
+chmod 640 /var/log/apt/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,8 +39,8 @@ curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh 
 echo "Create dockerenv file"
 touch /.dockerenv
 
-echo "Update permissions of log file"
-chmod 640 /var/log/apt/history.log
+echo "Update permissions of apt log files"
+chmod 640 /var/log/apt/*
 
 echo "UA hardening"
 usg fix cis_level1_server

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,3 +47,4 @@ apt-get purge --auto-remove -y \
   ubuntu-advantage-tools && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/lib/usg
+  

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,6 +47,3 @@ apt-get purge --auto-remove -y \
   ubuntu-advantage-tools && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/lib/usg
-
-echo "Update permissions of apt log files"
-chmod 640 /var/log/apt/*


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes updating permission changes on /var/log/apt/ log files, as the permissions get reset the next time apt is used
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

When we re-install the ubuntu advantage tools the permissions get reset, causing the audit to fail.
