### PR TITLE
remove grype from build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,9 +33,6 @@ ua attach --attach-config ua-attach-config.yaml
 apt-get -y -q install \
   usg \
 
-echo "Installing grype cli"
-curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
-
 echo "Create dockerenv file"
 touch /.dockerenv
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes grype from build script as we are adding grype to our common-pipeline scan script file
- Grype wasn't successfully being installed because we didn't have curl installed. This makes it so we don't have to have curl on every image.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removes grype so it isn't installed on every image. It will only be installed when it is needed.
