### PR TITLE
update to use disa stig

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,7 +37,7 @@ echo "Create dockerenv file"
 touch /.dockerenv
 
 echo "UA hardening"
-usg fix cis_level1_server
+usg fix disa_stig
 
 echo "Cleaning up ua"
 apt-get purge --auto-remove -y \


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the usg fix command to use disa stig instead of cis

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use disa stig
