### PR TITLE
use secrets option rather than args for token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu-hardened base docker image
-ARG base_image
+ARG base_image=ubuntu:22.04
 
 FROM ${base_image}
 RUN apt update && apt upgrade -y
@@ -10,11 +10,9 @@ COPY . /opt/concourse-ci/task
 # Set current working directory for executed scripts
 WORKDIR /opt/concourse-ci/task
 
-ARG TOKEN
-
 # Use a custom build script instead of messy chained together RUN
 # or multiple RUN statements that add bloat to the image
-RUN /opt/concourse-ci/task/scripts/build.sh
+RUN --mount=type=secret,id=TOKEN /opt/concourse-ci/task/scripts/build.sh
 
 # Run tests on the Docker build
 RUN /opt/concourse-ci/task/scripts/test.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ source ./config.sh
 
 echo "Configuring ua attach config"
 cat <<EOF >> ua-attach-config.yaml
-token: $TOKEN
+token: $(cat /run/secrets/TOKEN)
 enable_services:
 - usg
 - esm-infra
@@ -44,3 +44,4 @@ apt-get purge --auto-remove -y \
   ubuntu-advantage-tools && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/lib/usg
+rm ua-attach-config.yaml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Sets up the Dockerfile to use secrets option rather than arg for token

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Increased security for container images by using secrets option
