### PR TITLE
keep ua packages as removal may cause errors

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,7 +22,7 @@ ln -sf "/usr/share/zoneinfo/$SYSTEM_TIMEZONE" /etc/localtime
 apt-get update
 apt-get -y -q install \
   ubuntu-advantage-tools ca-certificates \
-  tzdata \
+  tzdata
 
 echo "Updating system timezone"
 ln -sf "/usr/share/zoneinfo/$SYSTEM_TIMEZONE" /etc/localtime
@@ -31,7 +31,7 @@ echo "UA attaching"
 ua attach --attach-config ua-attach-config.yaml
 
 apt-get -y -q install \
-  usg \
+  usg
 
 echo "Create dockerenv file"
 touch /.dockerenv
@@ -40,8 +40,4 @@ echo "UA hardening"
 usg fix cis_level1_server
 
 echo "Cleaning up ua"
-apt-get purge --auto-remove -y \
-  ubuntu-advantage-tools && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/lib/usg
 rm ua-attach-config.yaml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Keeping ua packages installed

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Keeping ua packages installed should keep us from experiencing errors with ubuntu packages and provide access to the ubuntu security packages provided by the ua tool