### PR TITLE
Disa stig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${base_image}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt upgrade -y
+RUN apt update -qq && apt upgrade -qq -y
 
 # Copy local project directories to container image
 COPY . /opt/concourse-ci/task

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 ARG base_image=ubuntu:22.04
 
 FROM ${base_image}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt update && apt upgrade -y
 
 # Copy local project directories to container image

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,10 +39,12 @@ touch /.dockerenv
 addgroup syslog
 
 chgrp syslog /var/log
-find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chmod 640 '{}' \;
 
 echo "UA hardening"
 usg fix disa_stig
 
 echo "Cleaning up ua"
 rm ua-attach-config.yaml
+
+echo "Update /var/log permissions"
+find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chmod 640 '{}' \;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,5 +42,4 @@ echo "UA hardening"
 usg fix disa_stig
 
 echo "Cleaning up ua"
-
 rm ua-attach-config.yaml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,8 +36,10 @@ apt-get -y -q install \
 echo "Create dockerenv file"
 touch /.dockerenv
 
+echo "Add syslog group"
 addgroup syslog
 
+echo "Update group ownership for folders/files"
 chgrp syslog /var/log
 
 if [ -e /bin/mail-touchlock ]; then
@@ -59,10 +61,11 @@ if [ -e /usr/bin/mail-unlock ]; then
   chgrp root /usr/bin/mail-unlock
 fi
 
+echo "add setting to show last login"
+sed -i '1isession required pam_lastlog.so showfailed' /etc/pam.d/login
+
 echo "UA hardening"
 usg fix disa_stig
 
 echo "Cleaning up ua"
 rm ua-attach-config.yaml
-
-echo "Update /var/log permissions"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,22 +40,22 @@ addgroup syslog
 
 chgrp syslog /var/log
 
-if [-e /bin/mail-touchlock ]; then
+if [ -e /bin/mail-touchlock ]; then
   chgrp root /bin/mail-touchlock
 fi
-if [-e /bin/mail-lock ]; then
+if [ -e /bin/mail-lock ]; then
   chgrp root /bin/mail-lock
 fi
-if [-e /bin/mail-unlock ]; then
+if [ -e /bin/mail-unlock ]; then
   chgrp root /bin/mail-unlock
 fi
-if [-e /usr/bin/mail-touchlock ]; then
+if [ -e /usr/bin/mail-touchlock ]; then
   chgrp root /usr/bin/mail-touchlock
 fi
-if [-e /usr/bin/mail-lock ]; then
+if [ -e /usr/bin/mail-lock ]; then
   chgrp root /usr/bin/mail-lock
 fi
-if [-e /usr/bin/mail-unlock ]; then
+if [ -e /usr/bin/mail-unlock ]; then
   chgrp root /usr/bin/mail-unlock
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,6 +39,7 @@ touch /.dockerenv
 addgroup syslog
 
 chgrp syslog /var/log
+find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chmod 640 '{}' \;
 
 echo "UA hardening"
 usg fix disa_stig

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,12 +40,24 @@ addgroup syslog
 
 chgrp syslog /var/log
 
-chgrp root /bin/mail-touchlock
-chgrp root /bin/mail-lock
-chgrp root /bin/mail-unlock
-chgrp root /usr/bin/mail-touchlock
-chgrp root /usr/bin/mail-lock
-chgrp root /usr/bin/mail-unlock
+if [-e /bin/mail-touchlock ]; then
+  chgrp root /bin/mail-touchlock
+fi
+if [-e /bin/mail-lock ]; then
+  chgrp root /bin/mail-lock
+fi
+if [-e /bin/mail-unlock ]; then
+  chgrp root /bin/mail-unlock
+fi
+if [-e /usr/bin/mail-touchlock ]; then
+  chgrp root /usr/bin/mail-touchlock
+fi
+if [-e /usr/bin/mail-lock ]; then
+  chgrp root /usr/bin/mail-lock
+fi
+if [-e /usr/bin/mail-unlock ]; then
+  chgrp root /usr/bin/mail-unlock
+fi
 
 echo "UA hardening"
 usg fix disa_stig

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,12 +38,7 @@ touch /.dockerenv
 
 addgroup syslog
 
-readarray -t files < <(find /var/log/)
-for file in "${files[@]}"; do
-    if basename $file | grep -qE '^.*$'; then
-        chmod 0640 $file
-    fi
-done
+chmod 0640 /var/log/syslog
 
 echo "UA hardening"
 usg fix disa_stig

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ echo "Updating system timezone"
 ln -sf "/usr/share/zoneinfo/$SYSTEM_TIMEZONE" /etc/localtime
 
 apt-get update
-apt-get -y -q install \
+apt-get -y -qq install \
   ubuntu-advantage-tools ca-certificates \
   tzdata
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,15 +38,10 @@ touch /.dockerenv
 
 addgroup syslog
 
+chgrp syslog /var/log
+
 echo "UA hardening"
 usg fix disa_stig
-
-readarray -t files < <(find /var/log/)
-for file in "${files[@]}"; do
-    if basename $file | grep -qE '^.*$'; then
-        chmod 0640 $file
-    fi
-done
 
 echo "Cleaning up ua"
 rm ua-attach-config.yaml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,8 +36,11 @@ apt-get -y -q install \
 echo "Create dockerenv file"
 touch /.dockerenv
 
+addgroup syslog
+
 echo "UA hardening"
 usg fix disa_stig
 
 echo "Cleaning up ua"
+
 rm ua-attach-config.yaml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,10 +38,15 @@ touch /.dockerenv
 
 addgroup syslog
 
-chmod 0640 /var/log/syslog
-
 echo "UA hardening"
 usg fix disa_stig
+
+readarray -t files < <(find /var/log/)
+for file in "${files[@]}"; do
+    if basename $file | grep -qE '^.*$'; then
+        chmod 0640 $file
+    fi
+done
 
 echo "Cleaning up ua"
 rm ua-attach-config.yaml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,6 +40,13 @@ addgroup syslog
 
 chgrp syslog /var/log
 
+chgrp root /bin/mail-touchlock
+chgrp root /bin/mail-lock
+chgrp root /bin/mail-unlock
+chgrp root /usr/bin/mail-touchlock
+chgrp root /usr/bin/mail-lock
+chgrp root /usr/bin/mail-unlock
+
 echo "UA hardening"
 usg fix disa_stig
 
@@ -47,4 +54,3 @@ echo "Cleaning up ua"
 rm ua-attach-config.yaml
 
 echo "Update /var/log permissions"
-find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chmod 640 '{}' \;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,7 +37,7 @@ echo "Create dockerenv file"
 touch /.dockerenv
 
 echo "UA hardening"
-usg fix cis_level1_server
+usg fix disa_stig
 
 echo "Cleaning up ua"
 rm ua-attach-config.yaml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,13 @@ touch /.dockerenv
 
 addgroup syslog
 
+readarray -t files < <(find /var/log/)
+for file in "${files[@]}"; do
+    if basename $file | grep -qE '^.*$'; then
+        chmod 0640 $file
+    fi
+done
+
 echo "UA hardening"
 usg fix disa_stig
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Move disa stig changes into the main branch

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Since all container images are now using the disa stig hardened ubuntu image we are making it the main branch, and we will remove the old cis level ubuntu-hardened image.
